### PR TITLE
focus-get-thing patch

### DIFF
--- a/focus.el
+++ b/focus.el
@@ -98,18 +98,12 @@ The timer calls `focus-read-only-hide-cursor' after
                focus-read-only-blink-timer))
   (make-local-variable var))
 
-(defun focus-any (f lst)
-  "Apply F to each element of LST and return first NON-NIL."
-  (when lst
-    (let ((v (funcall f (car lst))))
-      (if v v (focus-any f (cdr lst))))))
-
 (defun focus-get-thing ()
   "Return the current thing, based on `focus-mode-to-thing'."
   (or focus-current-thing
       (let* ((modes (mapcar 'car focus-mode-to-thing))
              (mode  (or (cl-find major-mode modes)
-                        (focus-any 'derived-mode-p modes))))
+                        (apply #'derived-mode-p modes))))
         (if mode (cdr (assoc mode focus-mode-to-thing)) 'sentence))))
 
 (defun focus-bounds ()

--- a/focus.el
+++ b/focus.el
@@ -108,7 +108,8 @@ The timer calls `focus-read-only-hide-cursor' after
   "Return the current thing, based on `focus-mode-to-thing'."
   (or focus-current-thing
       (let* ((modes (mapcar 'car focus-mode-to-thing))
-             (mode  (focus-any 'derived-mode-p modes)))
+             (mode  (or (cl-find major-mode modes)
+                        (focus-any 'derived-mode-p modes))))
         (if mode (cdr (assoc mode focus-mode-to-thing)) 'sentence))))
 
 (defun focus-bounds ()


### PR DESCRIPTION
Previously, a value for focus-mode-to-thing like:
```
'((prog-mode . defun)
  (text-mode . sentence)
  (org-mode . paragraph))
```
Wouldn't work, since org-mode is dervied from text-mode. Now focus-get-thing checks if the current mode is explicitly in focus-mode-to-thing before checking if it's a derived mode.

Also, `derived-mode-p` already takes a list of modes as arguments, so we can just apply it instead of calling it with a custom "any" function.