### PR TITLE
Keep colors and add Org mode support

### DIFF
--- a/focus.el
+++ b/focus.el
@@ -132,9 +132,9 @@ The timer calls `focus-read-only-hide-cursor' after
 
 (defun focus-dim-buffer ()
   "Dim the colors of relevant faces in the buffer."
+  (focus-reset-remapping)
   ;; Most faces that alters the background are better left undimmed. The
   ;; default face is, however, a clear exception.
-  (focus-reset-remapping)
   (focus-remap-foreground-color-from-face 'default)
   (dolist (face (face-list))
     (when (and (not (face-background face))

--- a/focus.el
+++ b/focus.el
@@ -116,16 +116,20 @@ The timer calls `focus-read-only-hide-cursor' after
                         (apply #'derived-mode-p modes))))
         (if mode (cdr (assoc mode focus-mode-to-thing)) 'sentence))))
 
+(defun focus-org-element-bounds ()
+  "Extract bounds from `org-element-at-point'"
+  (let* ((elem (org-element-at-point))
+         (beg (org-element-property :begin elem))
+         (end (org-element-property :end elem)))
+    (and beg end (cons beg end))))
+
+(put 'org-element 'bounds-of-thing-at-point
+     #'focus-org-element-bounds)
+
 (defun focus-bounds ()
   "Return the current bounds, based on `focus-get-thing'."
   (or focus-pin-bounds
-      (let ((thing (focus-get-thing)))
-        (cond ((eq thing 'org-element)
-               (let* ((elem (org-element-at-point))
-                      (beg (org-element-property :begin elem))
-                      (end (org-element-property :end elem)))
-                 (and beg end (cons beg end))))
-              (t (bounds-of-thing-at-point thing))))))
+      (bounds-of-thing-at-point (focus-get-thing))))
 
 (defun focus-window-bounds ()
   (cons (window-start) (window-end nil t)))

--- a/focus.el
+++ b/focus.el
@@ -183,24 +183,25 @@ If `focus-mode' is enabled, this function is added to
 `post-command-hook' and `window-scroll-functions'. The function
 can be called with an arbitrary number of ARGS to support being
 called from `window-scroll-functions'."
-  (with-current-buffer focus-buffer
-    (let* ((bg (face-background 'default))
-           (window-bounds (focus-window-bounds))
-           (bounds (focus-bounds)))
-      (when (and bounds (or (not (equal bg focus-last-background))
-                            (not (equal window-bounds focus-last-window-bounds))
-                            (not (equal bounds focus-last-bounds))))
-        (let ((start (car window-bounds))
-              (end (cdr window-bounds))
-              (low (car bounds))
-              (high (cdr bounds)))
-          (focus-remove-unfocused-overlays)
-          (focus-dim-area start low)
-          (focus-dim-area high end)
-          (move-overlay focus-focused-overlay low high)))
-      (setq focus-last-background bg)
-      (setq focus-last-window-bounds window-bounds)
-      (setq focus-last-bounds bounds))))
+  (while-no-input
+    (with-current-buffer focus-buffer
+      (let* ((bg (face-background 'default))
+             (window-bounds (focus-window-bounds))
+             (bounds (focus-bounds)))
+        (when (and bounds (or (not (equal bg focus-last-background))
+                              (not (equal window-bounds focus-last-window-bounds))
+                              (not (equal bounds focus-last-bounds))))
+          (let ((start (car window-bounds))
+                (end (cdr window-bounds))
+                (low (car bounds))
+                (high (cdr bounds)))
+            (focus-remove-unfocused-overlays)
+            (focus-dim-area start low)
+            (focus-dim-area high end)
+            (move-overlay focus-focused-overlay low high)))
+        (setq focus-last-background bg)
+        (setq focus-last-window-bounds window-bounds)
+        (setq focus-last-bounds bounds)))))
 
 (defun focus-make-focused-overlay ()
   (let ((o (make-overlay (point-min) (point-max))))

--- a/focus.el
+++ b/focus.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'org-element)
 (require 'thingatpt)
 
 (defgroup focus ()
@@ -38,7 +39,9 @@
   :group 'font-lock
   :prefix "focus-")
 
-(defcustom focus-mode-to-thing '((prog-mode . defun) (text-mode . sentence))
+(defcustom focus-mode-to-thing '((prog-mode . defun)
+                                 (text-mode . paragraph)
+                                 (org-mode . org-element))
   "An associated list between mode and thing.
 
 A thing is defined in thingatpt.el; the thing determines the
@@ -101,7 +104,13 @@ The timer calls `focus-read-only-hide-cursor' after
 
 (defun focus-bounds ()
   "Return the current bounds, based on `focus-get-thing'."
-  (bounds-of-thing-at-point (focus-get-thing)))
+  (let ((thing (focus-get-thing)))
+    (cond ((eq thing 'org-element)
+           (let* ((elem (org-element-at-point))
+                  (beg (org-element-property :begin elem))
+                  (end (org-element-property :end elem)))
+             (cons beg end)))
+          (t (bounds-of-thing-at-point (focus-get-thing))))))
 
 (defun focus-move-focus ()
   "Move the focused section according to `focus-bounds'.
@@ -165,7 +174,7 @@ according to major-mode. If `focus-current-thing' is set, this
 default is overwritten. This function simply helps set the
 `focus-current-thing'."
   (interactive)
-  (let* ((candidates '(defun line list paragraph sentence sexp symbol word))
+  (let* ((candidates '(defun line list org-element paragraph sentence sexp symbol word))
          (thing (completing-read "Thing: " candidates)))
     (setq focus-current-thing (intern thing))))
 

--- a/focus.el
+++ b/focus.el
@@ -142,13 +142,13 @@ The timer calls `focus-read-only-hide-cursor' after
 (defun focus-make-unfocused-face (fg)
   "Add dimmed foreground color FG to the `focus-unfocused` face."
   (let ((bg (face-background 'default)))
-    (when (and fg bg (color-defined-p fg) (color-defined-p bg))
-      (if (color-defined-p (face-attribute 'focus-unfocused :foreground))
-          'focus-unfocused
+    (if (and fg bg (color-defined-p fg) (color-defined-p bg)
+             (not (color-defined-p (face-attribute 'focus-unfocused :foreground))))
         (plist-put (face-attr-construct 'focus-unfocused)
                    :foreground (focus-lerp (color-name-to-rgb fg)
                                            (color-name-to-rgb bg)
-                                           focus-fraction))))))
+                                           focus-fraction))
+      'focus-unfocused)))
 
 (defun focus-foreground-from-face (face)
   "Return foreground color for FACE, or 'default if nil."

--- a/focus.el
+++ b/focus.el
@@ -173,13 +173,14 @@ The timer calls `focus-read-only-hide-cursor' after
   "Restore original colors between LOW and HIGH.
 
 Returns the list of added overlays."
-  (let* ((next (min high (or (next-property-change low) high)))
-         (face (get-text-property low 'face))
-         (fg (focus-foreground-from-face face))
-         (restored-face (focus-make-focused-face fg))
-         (o (make-overlay low next)))
-    (overlay-put o 'face restored-face)
-    (cons o (when (< low high) (focus-undim-area next high)))))
+  (when (< low high)
+    (let* ((next (min high (or (next-property-change low) high)))
+           (face (get-text-property low 'face))
+           (fg (focus-foreground-from-face face))
+           (restored-face (focus-make-focused-face fg))
+           (o (make-overlay low next)))
+      (overlay-put o 'face restored-face)
+      (cons o (focus-undim-area next high)))))
 
 (defun focus-move-focus ()
   "Move the focused section according to `focus-bounds'.

--- a/focus.el
+++ b/focus.el
@@ -77,7 +77,7 @@ Things that are defined include `symbol', `list', `sexp',
   :group 'focus)
 
 (defvar focus-cursor-type cursor-type
-  "Used to restore the users `cursor-type'")
+  "Used to restore the users `cursor-type'.")
 
 (defvar-local focus-current-thing nil
   "Overrides the choice of thing dictated by `focus-mode-to-thing' if set.")
@@ -207,7 +207,7 @@ command."
   (move-overlay focus-post-overlay high (point-max)))
 
 (defun focus-init ()
-  "This function runs when `focus-mode' is enabled.
+  "This function run when command `focus-mode' is enabled.
 
 It sets the `focus-pre-overlay', `focus-min-overlay', and
 `focus-post-overlay' to overlays; these are invisible until

--- a/focus.el
+++ b/focus.el
@@ -156,7 +156,7 @@ The timer calls `focus-read-only-hide-cursor' after
            (let* ((elem (org-element-at-point))
                   (beg (org-element-property :begin elem))
                   (end (org-element-property :end elem)))
-             (cons beg end)))
+             (and beg end (cons beg end))))
           (t (bounds-of-thing-at-point thing)))))
 
 (defun focus-make-focused-face (fg)


### PR DESCRIPTION
This pull request mainly addresses #2. It calculates a suitable foreground color for the region out of focus.

Doing this is significantly more resource demanding, so some effort has been made to avoid redundant computations. This includes to only recalculate when the focused area changes, only change the colors within the bounds of the window and ignore all invisible text (which can typically occur in Org-mode buffers with hidden subtrees).

The changes require a user to explicitly set a foreground in the `focus-unfocused` face when using Focus without a theme (#21 ). The reason for this is to allow this feature to co-exist with other customizations of the `focus-unfocused` and `focus-focused` faces (e.g. changing the size of the unfocused text, or making the focused area bold).

Additionally, using Focus with Org-mode has been improved, by using [org-element](https://orgmode.org/worg/dev/org-element-api.html) to provide a reasonable chunk to Focus on.