### PR TITLE
default to paragraph-at-point for special-mode

### DIFF
--- a/focus.el
+++ b/focus.el
@@ -40,6 +40,7 @@
 
 (defcustom focus-mode-to-thing '((prog-mode . defun)
                                  (text-mode . paragraph)
+                                 (special-mode . paragraph)
                                  (org-mode . org-element))
   "An associated list between mode and thing.
 


### PR DESCRIPTION
Both eww-mode and gnus-article-mode derive from special-mode, it makes sense to use paragraph mode for these. The other special-modes don't seem like the kind where you'd want focus-mode on.

(`grep -Rohan 'define-derived-mode.*special-mode' lisp/` in emacs sources to see other things deriving from special-mode)