### PR TITLE
Fix compilation warnings

### DIFF
--- a/focus.el
+++ b/focus.el
@@ -33,6 +33,9 @@
 (require 'cl-lib)
 (require 'thingatpt)
 
+(declare-function org-element-property "org-element" (property element))
+(declare-function org-element-at-point "org-element" (&optional pom cached-only))
+
 (defgroup focus ()
   "Dim the font color of text in surrounding sections."
   :group 'font-lock


### PR DESCRIPTION
Compiling `focus` results in compilation warnings relating to two functions from the `org-element' library. We can tell the byte compiler where those functions are located without explicitly requiring the library.

Without this change, the following warnings are displayed during installation:

```
package/focus/focus.el:130:25: Warning: the function ‘org-element-property’ is not known to be defined.
package/focus/focus.el:129:26: Warning: the function ‘org-element-at-point’ is not known to be defined.
```